### PR TITLE
Add support for 'base36' and 'base36upper' multibase encodings

### DIFF
--- a/multibase/converters.py
+++ b/multibase/converters.py
@@ -1,4 +1,3 @@
-import base64
 from io import BytesIO
 from itertools import zip_longest
 

--- a/multibase/multibase.py
+++ b/multibase/multibase.py
@@ -15,12 +15,15 @@ ENCODINGS = [
     Encoding('base32hex', b'v', Base32StringConverter('0123456789abcdefghijklmnopqrstuv')),
     Encoding('base32', b'b', Base32StringConverter('abcdefghijklmnopqrstuvwxyz234567')),
     Encoding('base32z', b'h', BaseStringConverter('ybndrfg8ejkmcpqxot1uwisza345h769')),
+    Encoding('base36', b'k', BaseStringConverter('0123456789abcdefghijklmnopqrstuvwxyz')),
+    Encoding('base36upper', b'K', BaseStringConverter('0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ')),
     Encoding('base58flickr', b'Z', BaseStringConverter('123456789abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ')),
     Encoding('base58btc', b'z', BaseStringConverter('123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz')),
     Encoding('base64', b'm', Base64StringConverter('ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/')),
     Encoding('base64url', b'u',
-        Base64StringConverter('ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_'),
-    ),
+             Base64StringConverter(
+                 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_'),
+             ),
 ]
 
 ENCODINGS_LOOKUP = {}

--- a/tests/test_multibase.py
+++ b/tests/test_multibase.py
@@ -58,6 +58,10 @@ TEST_FIXTURES = (
     # ('base32hexpad', 'foobar', 'tcpnmuoj1e8======'),
 
     ('base32z', 'yes mani !', 'hxf1zgedpcfzg1ebb'),
+
+    ('base36', 'Decentralize everything!!!', 'km552ng4dabi4neu1oo8l4i5mndwmpc3mkukwtxy9'),
+    ('base36upper', 'Decentralize everything!!!', 'KM552NG4DABI4NEU1OO8L4I5MNDWMPC3MKUKWTXY9'),
+
     ('base58flickr', 'yes mani !', 'Z7Pznk19XTTzBtx'),
     ('base58btc', 'yes mani !', 'z7paNL19xttacUY'),
 


### PR DESCRIPTION
I was perusing [multiformats/py-multibase's fork network](https://github.com/multiformats/py-multibase/network) and found this great work by [pinnaculum](https://github.com/pinnaculum/py-multibase/tree/base36).

What do you guys think?