### PR TITLE
Remove custom __init__ from Base16StringConverter

### DIFF
--- a/multibase/converters.py
+++ b/multibase/converters.py
@@ -29,9 +29,6 @@ class BaseStringConverter(BaseConverter):
 
 
 class Base16StringConverter(BaseStringConverter):
-    def __init__(self):
-        self.digits = '0123456789abcdef'
-
     def encode(self, bytes):
         return ensure_bytes(''.join(['{:02x}'.format(byte) for byte in bytes]))
 

--- a/multibase/multibase.py
+++ b/multibase/multibase.py
@@ -11,7 +11,7 @@ ENCODINGS = [
     Encoding('base2', b'0', BaseStringConverter('01')),
     Encoding('base8', b'7', BaseStringConverter('01234567')),
     Encoding('base10', b'9', BaseStringConverter('0123456789')),
-    Encoding('base16', b'f', Base16StringConverter()),
+    Encoding('base16', b'f', Base16StringConverter('0123456789abcdef')),
     Encoding('base32hex', b'v', Base32StringConverter('0123456789abcdefghijklmnopqrstuv')),
     Encoding('base32', b'b', Base32StringConverter('abcdefghijklmnopqrstuvwxyz234567')),
     Encoding('base32z', b'h', BaseStringConverter('ybndrfg8ejkmcpqxot1uwisza345h769')),


### PR DESCRIPTION
It was messing up the hierarchy, because it had `super().__init__()` call.
Instead of adding that call, I just passed its `digits` attribute as
an argument to the default inherited constructor from BaseConverter
which is exactly what *all* the other Base*StringConverter classes are doing.